### PR TITLE
Add new "Chain" arrow type

### DIFF
--- a/src/main/java/wtf/choco/arrows/AlchemicalArrows.java
+++ b/src/main/java/wtf/choco/arrows/AlchemicalArrows.java
@@ -65,7 +65,7 @@ public class AlchemicalArrows extends JavaPlugin {
     public static final String CHAT_PREFIX = ChatColor.GOLD.toString() + ChatColor.BOLD + "AlchemicalArrows | " + ChatColor.GRAY;
 
     private static final int RESOURCE_ID = 11693;
-    private static final String SPIGOT_LINK = "https://api.spigot.org/v2/resources/" + RESOURCE_ID + "/versions/latest";
+    private static final String SPIGET_LINK = "https://api.spiget.org/v2/resources/" + RESOURCE_ID + "/versions/latest";
 
     private static final Gson GSON = new Gson();
     private static AlchemicalArrows instance;
@@ -122,7 +122,7 @@ public class AlchemicalArrows extends JavaPlugin {
         // Register alchemical arrows
         this.getLogger().info("Registering default alchemical arrows and their recipes");
         this.createArrow(new AlchemicalArrowAir(this), "Air", Material.FEATHER); // Custom model data 132 (+1 for every registration)
-        this.createArrow(new AlchemicalArrowChain(this), "Chain", Material.FIREWORK_ROCKET);
+        this.createArrow(new AlchemicalArrowChain(this), "Chain", Material.SLIME_BALL);
         this.createArrow(new AlchemicalArrowConfusion(this), "Confusion", Material.POISONOUS_POTATO);
         this.createArrow(new AlchemicalArrowDarkness(this), "Darkness", Material.COAL, Material.CHARCOAL);
         this.createArrow(new AlchemicalArrowDeath(this), "Death", Material.WITHER_SKELETON_SKULL);
@@ -162,7 +162,7 @@ public class AlchemicalArrows extends JavaPlugin {
             metrics.addCustomChart(new Metrics.SimplePie("crafting_type", () -> getConfig().getBoolean("Crafting.CauldronCrafting", true) ? "Cauldron Crafting" : "Vanilla Crafting"));
         }
 
-        // Check for newer version (Spigot API)
+        // Check for newer version (Spiget API)
         if (getConfig().getBoolean("CheckForUpdates", true)) {
             this.getLogger().info("Getting version information...");
             this.doVersionCheck();
@@ -262,7 +262,7 @@ public class AlchemicalArrows extends JavaPlugin {
 
     private void doVersionCheck() {
         Bukkit.getScheduler().runTaskAsynchronously(this, () -> {
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(new URL(SPIGOT_LINK).openStream()))) {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(new URL(SPIGET_LINK).openStream()))) {
                 JsonObject object = GSON.fromJson(reader, JsonObject.class);
                 String currentVersion = getDescription().getVersion(), recentVersion = object.get("name").getAsString();
 

--- a/src/main/java/wtf/choco/arrows/AlchemicalArrows.java
+++ b/src/main/java/wtf/choco/arrows/AlchemicalArrows.java
@@ -65,7 +65,7 @@ public class AlchemicalArrows extends JavaPlugin {
     public static final String CHAT_PREFIX = ChatColor.GOLD.toString() + ChatColor.BOLD + "AlchemicalArrows | " + ChatColor.GRAY;
 
     private static final int RESOURCE_ID = 11693;
-    private static final String SPIGET_LINK = "https://api.spiget.org/v2/resources/" + RESOURCE_ID + "/versions/latest";
+    private static final String SPIGOT_LINK = "https://api.spigot.org/v2/resources/" + RESOURCE_ID + "/versions/latest";
 
     private static final Gson GSON = new Gson();
     private static AlchemicalArrows instance;
@@ -122,6 +122,7 @@ public class AlchemicalArrows extends JavaPlugin {
         // Register alchemical arrows
         this.getLogger().info("Registering default alchemical arrows and their recipes");
         this.createArrow(new AlchemicalArrowAir(this), "Air", Material.FEATHER); // Custom model data 132 (+1 for every registration)
+        this.createArrow(new AlchemicalArrowChain(this), "Chain", Material.FIREWORK_ROCKET);
         this.createArrow(new AlchemicalArrowConfusion(this), "Confusion", Material.POISONOUS_POTATO);
         this.createArrow(new AlchemicalArrowDarkness(this), "Darkness", Material.COAL, Material.CHARCOAL);
         this.createArrow(new AlchemicalArrowDeath(this), "Death", Material.WITHER_SKELETON_SKULL);
@@ -161,7 +162,7 @@ public class AlchemicalArrows extends JavaPlugin {
             metrics.addCustomChart(new Metrics.SimplePie("crafting_type", () -> getConfig().getBoolean("Crafting.CauldronCrafting", true) ? "Cauldron Crafting" : "Vanilla Crafting"));
         }
 
-        // Check for newer version (Spiget API)
+        // Check for newer version (Spigot API)
         if (getConfig().getBoolean("CheckForUpdates", true)) {
             this.getLogger().info("Getting version information...");
             this.doVersionCheck();
@@ -261,7 +262,7 @@ public class AlchemicalArrows extends JavaPlugin {
 
     private void doVersionCheck() {
         Bukkit.getScheduler().runTaskAsynchronously(this, () -> {
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(new URL(SPIGET_LINK).openStream()))) {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(new URL(SPIGOT_LINK).openStream()))) {
                 JsonObject object = GSON.fromJson(reader, JsonObject.class);
                 String currentVersion = getDescription().getVersion(), recentVersion = object.get("name").getAsString();
 

--- a/src/main/java/wtf/choco/arrows/arrow/AlchemicalArrowChain.java
+++ b/src/main/java/wtf/choco/arrows/arrow/AlchemicalArrowChain.java
@@ -1,0 +1,78 @@
+package wtf.choco.arrows.arrow;
+
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.World;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.AbstractArrow;
+import org.bukkit.entity.Arrow;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.util.Vector;
+import wtf.choco.arrows.AlchemicalArrows;
+import wtf.choco.arrows.api.AlchemicalArrowEntity;
+import wtf.choco.arrows.api.property.ArrowProperty;
+
+import java.util.Random;
+
+
+public class AlchemicalArrowChain extends AlchemicalArrowAbstract {
+
+    public AlchemicalArrowChain(AlchemicalArrows plugin) {
+        super(plugin, "Chain", "&f&nChain Arrow");
+
+        FileConfiguration config = plugin.getConfig();
+        this.properties.setProperty(ArrowProperty.SKELETONS_CAN_SHOOT, config.getBoolean("Arrow.Chain.Skeleton.CanShoot", true));
+        this.properties.setProperty(ArrowProperty.ALLOW_INFINITY, config.getBoolean("Arrow.Chain.AllowInfinity", false));
+        this.properties.setProperty(ArrowProperty.SKELETON_LOOT_WEIGHT, config.getDouble("Arrow.Chain.Skeleton.LootDropWeight", 10.0));
+    }
+
+    @Override
+    public void tick(AlchemicalArrowEntity arrow, Location location) {
+        World world = location.getWorld();
+        if (world == null) return;
+
+        world.spawnParticle(Particle.CRIT, location, 1, 0.1, 0.1, 0.1, 0.001);
+    }
+
+    @Override
+    public void onHitPlayer(AlchemicalArrowEntity arrow, Player player) {
+        Arrow bukkitArrow = arrow.getArrow();
+        this.attemptChain(bukkitArrow, (LivingEntity) bukkitArrow.getShooter(), (LivingEntity) player);
+        bukkitArrow.remove();
+    }
+
+    @Override
+    public void onHitEntity(AlchemicalArrowEntity arrow, Entity entity) {
+        Arrow bukkitArrow = arrow.getArrow();
+        this.attemptChain(bukkitArrow, (LivingEntity) bukkitArrow.getShooter(), (LivingEntity) entity);
+        bukkitArrow.remove();
+    }
+
+    /*
+    Chain the arrow to other nearby targets.
+     */
+    private void attemptChain(Arrow source, LivingEntity shooter, LivingEntity hitEntity) {
+        if(shooter == hitEntity){
+            return;
+        }
+        World world = source.getWorld();
+        // Source location is center of hit entity instead of their feet
+        Location newArrowSourceLoc = hitEntity.getLocation().add(0,hitEntity.getHeight() / 2,0);
+        for(Entity newTarget : world.getNearbyEntities(newArrowSourceLoc,5,5,5)){
+            // Don't chain to non-living entities, shooter or the original hit entity
+            if(!(newTarget instanceof LivingEntity) || newTarget == hitEntity || newTarget == shooter) {
+                continue;
+            }
+            // Calc vector to center of new target entity
+            Vector dirToTarget = newTarget.getLocation().toVector().add(new Vector(0,newTarget.getHeight() / 2,0)).subtract(newArrowSourceLoc.toVector());
+            Arrow chainArrow = world.spawnArrow(newArrowSourceLoc,dirToTarget, 1.2F,12);
+            chainArrow.setShooter(shooter);
+            chainArrow.setDamage(chainArrow.getDamage() * 0.80);
+            chainArrow.setPickupStatus(AbstractArrow.PickupStatus.DISALLOWED);
+            world.playSound(newArrowSourceLoc, Sound.ENTITY_ARROW_SHOOT,1,1);
+        }
+    }
+}

--- a/src/main/java/wtf/choco/arrows/arrow/AlchemicalArrowChain.java
+++ b/src/main/java/wtf/choco/arrows/arrow/AlchemicalArrowChain.java
@@ -1,6 +1,7 @@
 package wtf.choco.arrows.arrow;
 
 import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.World;
@@ -10,23 +11,34 @@ import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.projectiles.ProjectileSource;
 import org.bukkit.util.Vector;
 import wtf.choco.arrows.AlchemicalArrows;
 import wtf.choco.arrows.api.AlchemicalArrowEntity;
 import wtf.choco.arrows.api.property.ArrowProperty;
 
-import java.util.Random;
-
 
 public class AlchemicalArrowChain extends AlchemicalArrowAbstract {
 
+    private static final ArrowProperty<Double> CHAIN_DAMAGE_FACTOR = new ArrowProperty<>(new NamespacedKey(AlchemicalArrows.getInstance(), "damage_factor"), Double.class, 0.80);
+    private static final ArrowProperty<Integer> CHAIN_SEARCH_DISTANCE = new ArrowProperty<>(new NamespacedKey(AlchemicalArrows.getInstance(), "search_distance"), Integer.class, 5);
+
+    private static final int SEARCH_DISTANCE_MAX = 10;
+    private static final int SEARCH_DISTANCE_MIN = 1;
+
+    private static final double DAMAGE_FACTOR_MAX = 1.0;
+    private static final double DAMAGE_FACTOR_MIN = 0.0;
+
     public AlchemicalArrowChain(AlchemicalArrows plugin) {
-        super(plugin, "Chain", "&f&nChain Arrow");
+        super(plugin, "Chain", "&2&nChain Arrow");
 
         FileConfiguration config = plugin.getConfig();
         this.properties.setProperty(ArrowProperty.SKELETONS_CAN_SHOOT, config.getBoolean("Arrow.Chain.Skeleton.CanShoot", true));
         this.properties.setProperty(ArrowProperty.ALLOW_INFINITY, config.getBoolean("Arrow.Chain.AllowInfinity", false));
         this.properties.setProperty(ArrowProperty.SKELETON_LOOT_WEIGHT, config.getDouble("Arrow.Chain.Skeleton.LootDropWeight", 10.0));
+
+        this.properties.setProperty(CHAIN_DAMAGE_FACTOR, Math.max(DAMAGE_FACTOR_MIN, Math.min(config.getDouble("Arrow.Chain.Effect.DamageFactor", 0.80), DAMAGE_FACTOR_MAX)));
+        this.properties.setProperty(CHAIN_SEARCH_DISTANCE, Math.max(SEARCH_DISTANCE_MIN, Math.min(config.getInt("Arrow.Chain.Effect.SearchDistance", 5), SEARCH_DISTANCE_MAX)));
     }
 
     @Override
@@ -34,43 +46,46 @@ public class AlchemicalArrowChain extends AlchemicalArrowAbstract {
         World world = location.getWorld();
         if (world == null) return;
 
-        world.spawnParticle(Particle.CRIT, location, 1, 0.1, 0.1, 0.1, 0.001);
+        world.spawnParticle(Particle.SLIME, location, 1, 0.1, 0.1, 0.1, 0.001);
     }
 
     @Override
     public void onHitPlayer(AlchemicalArrowEntity arrow, Player player) {
         Arrow bukkitArrow = arrow.getArrow();
-        this.attemptChain(bukkitArrow, (LivingEntity) bukkitArrow.getShooter(), (LivingEntity) player);
+        this.attemptChain(bukkitArrow, bukkitArrow.getShooter(), player);
         bukkitArrow.remove();
     }
 
     @Override
     public void onHitEntity(AlchemicalArrowEntity arrow, Entity entity) {
         Arrow bukkitArrow = arrow.getArrow();
-        this.attemptChain(bukkitArrow, (LivingEntity) bukkitArrow.getShooter(), (LivingEntity) entity);
+        this.attemptChain(bukkitArrow, bukkitArrow.getShooter(), (LivingEntity) entity);
         bukkitArrow.remove();
     }
 
     /*
     Chain the arrow to other nearby targets.
      */
-    private void attemptChain(Arrow source, LivingEntity shooter, LivingEntity hitEntity) {
-        if(shooter == hitEntity){
+    private void attemptChain(Arrow source, ProjectileSource shooter, LivingEntity hitEntity) {
+        if(shooter == hitEntity) {
             return;
         }
+
         World world = source.getWorld();
         // Source location is center of hit entity instead of their feet
         Location newArrowSourceLoc = hitEntity.getLocation().add(0,hitEntity.getHeight() / 2,0);
-        for(Entity newTarget : world.getNearbyEntities(newArrowSourceLoc,5,5,5)){
+        int searchRadius = properties.getProperty(CHAIN_SEARCH_DISTANCE).orElse(5);
+        for(Entity newTarget : world.getNearbyEntities(newArrowSourceLoc,searchRadius,searchRadius,searchRadius)){
             // Don't chain to non-living entities, shooter or the original hit entity
             if(!(newTarget instanceof LivingEntity) || newTarget == hitEntity || newTarget == shooter) {
                 continue;
             }
+
             // Calc vector to center of new target entity
             Vector dirToTarget = newTarget.getLocation().toVector().add(new Vector(0,newTarget.getHeight() / 2,0)).subtract(newArrowSourceLoc.toVector());
             Arrow chainArrow = world.spawnArrow(newArrowSourceLoc,dirToTarget, 1.2F,12);
             chainArrow.setShooter(shooter);
-            chainArrow.setDamage(chainArrow.getDamage() * 0.80);
+            chainArrow.setDamage(chainArrow.getDamage() * properties.getProperty(CHAIN_DAMAGE_FACTOR).orElse(0.80));
             chainArrow.setPickupStatus(AbstractArrow.PickupStatus.DISALLOWED);
             world.playSound(newArrowSourceLoc, Sound.ENTITY_ARROW_SHOOT,1,1);
         }

--- a/src/main/java/wtf/choco/arrows/listeners/ProjectileShootListener.java
+++ b/src/main/java/wtf/choco/arrows/listeners/ProjectileShootListener.java
@@ -6,6 +6,7 @@ import java.util.Random;
 import com.google.common.collect.Iterables;
 
 import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.enchantments.Enchantment;
@@ -83,7 +84,7 @@ public final class ProjectileShootListener implements Listener {
             if ((mainHand != null && mainHand.containsEnchantment(Enchantment.ARROW_INFINITE))
                 || (offHand != null && offHand.containsEnchantment(Enchantment.ARROW_INFINITE))) {
 
-                if (!type.getProperties().getProperty(ArrowProperty.ALLOW_INFINITY).orElse(true)) {
+                if (!type.getProperties().getProperty(ArrowProperty.ALLOW_INFINITY).orElse(true) && player.getGameMode() != GameMode.CREATIVE) {
                     if (arrowItem.getAmount() > 1) {
                         arrowItem.setAmount(arrowItem.getAmount() - 1);
                         inventory.setItem(arrowSlot, arrowItem);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -29,7 +29,20 @@ Arrow:
       Lore:
       - "&f&oFeel the air beneath your feet"
       - "&f&oDamaged entities are launched into the air"
-  
+
+  Chain:
+    RecipeYield: 8
+    AllowInfinity: false
+    Colour: '255,255,255'
+    Skeleton:
+      CanShoot: true
+      LootDropWeight: 10.0
+    Item:
+      DisplayName: "&f&nChain Arrow"
+      Lore:
+        - "&fQuick crowd dispersal"
+        - "&fChains to other nearby entities"
+
   Confusion:
     RecipeYield: 8
     AllowInfinity: false

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -33,15 +33,18 @@ Arrow:
   Chain:
     RecipeYield: 8
     AllowInfinity: false
-    Colour: '255,255,255'
+    Colour: '0,170,0'
+    Effect:
+      DamageFactor: 0.80
+      SearchDistance: 5
     Skeleton:
       CanShoot: true
       LootDropWeight: 10.0
     Item:
-      DisplayName: "&f&nChain Arrow"
+      DisplayName: "&2&nChain Arrow"
       Lore:
-        - "&fQuick crowd dispersal"
-        - "&fChains to other nearby entities"
+        - "&2Quick crowd dispersal"
+        - "&2Chains to other nearby entities"
 
   Confusion:
     RecipeYield: 8

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -28,6 +28,7 @@ permissions:
         default: true
         children:
             arrows.shoot.air: true
+            arrows.shoot.chain: true
             arrows.shoot.confusion: true
             arrows.shoot.darkness: true
             arrows.shoot.death: true
@@ -48,6 +49,7 @@ permissions:
         default: true
         children:
             arrows.craft.air: true
+            arrows.craft.chain: true
             arrows.craft.confusion: true
             arrows.craft.darkness: true
             arrows.craft.death: true


### PR DESCRIPTION
When the "Chain" arrow hits a living entity, reduced damage vanilla arrows shoot out from the hit entity directly towards any other nearby living entities.

I was play-testing on 1.15.2 PaperSpigot. No errors were encountered with any of the arrow types.